### PR TITLE
Pr upstream

### DIFF
--- a/app/src/main/java/org/tribler/app_to_appcommunicator/OverviewActivity.java
+++ b/app/src/main/java/org/tribler/app_to_appcommunicator/OverviewActivity.java
@@ -96,7 +96,7 @@ public class OverviewActivity extends AppCompatActivity {
         incomingList = new ArrayList<>();
         outgoingList = new ArrayList<>();
         hashId = getId();
-        if(hashId.toString().length() > 4){
+        if(hashId.toString().length() >= 4){
             ((TextView) findViewById(R.id.peer_id)).setText(hashId.toString().substring(0, 4));
         } else {
             ((TextView) findViewById(R.id.peer_id)).setText(hashId.toString());

--- a/app/src/main/java/org/tribler/app_to_appcommunicator/OverviewActivity.java
+++ b/app/src/main/java/org/tribler/app_to_appcommunicator/OverviewActivity.java
@@ -96,7 +96,11 @@ public class OverviewActivity extends AppCompatActivity {
         incomingList = new ArrayList<>();
         outgoingList = new ArrayList<>();
         hashId = getId();
-        ((TextView) findViewById(R.id.peer_id)).setText(hashId.toString().substring(0, 4));
+        if(hashId.toString().length() > 4){
+            ((TextView) findViewById(R.id.peer_id)).setText(hashId.toString().substring(0, 4));
+        } else {
+            ((TextView) findViewById(R.id.peer_id)).setText(hashId.toString());
+        }
         wanVote = new WanVote();
         outBuffer = ByteBuffer.allocate(BUFFER_SIZE);
         mWanVote = (TextView) findViewById(R.id.wanvote);


### PR DESCRIPTION
Due to the introduction of usernames in the Trustchain Android app (https://github.com/wkmeijer/CS4160-trustchain-android) there was a possibility for the App-To-App communicator to crash when they are connected to the same bootstrap phone. This was due to the fact that the App-To-App communicator assumes that the usernames should be larger than 4 characters long, this is fixed by a simple if statement. 